### PR TITLE
Fix Deprecated Warning

### DIFF
--- a/lib/ex_enum.ex
+++ b/lib/ex_enum.ex
@@ -18,20 +18,20 @@ defmodule ExEnum do
       end
       def get_by(kw) do
         unless Keyword.keyword?(kw), do: unquote(__MODULE__).argument_type_error(kw, "keyword list")
-        all |> Enum.find(&((kw -- Enum.into(&1, [])) == []))
+        all() |> Enum.find(&((kw -- Enum.into(&1, [])) == []))
       end
       def get_by!(kw) do
         get_by(kw) |> check_result!
       end
       def select(fields) when is_list(fields) do
-        Enum.map all, fn(row) ->
+        Enum.map all(), fn(row) ->
           Enum.reduce fields, {}, fn(field, acc) ->
             Tuple.append(acc, row[field])
           end
         end
       end
       def select(field) when is_atom(field) do
-        Enum.map all, &(&1[field])
+        Enum.map all(), &(&1[field])
       end
       defp check_result!(p) do
         p || raise RuntimeError, "no result"

--- a/mix.exs
+++ b/mix.exs
@@ -9,11 +9,11 @@ defmodule ExEnum.Mixfile do
      elixir: "~> 1.2",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps, 
+     deps: deps(),
 
      # Hex
-     description: description,
-     package: package]
+     description: description(),
+     package: package()]
   end
 
   defp description do


### PR DESCRIPTION
fix deprecated warning

```
[nishio@nishio-local] $ mix deps.get                                                                                                                                                                               
warning: variable "deps" does not exist and is being expanded to "deps()", please use parentheses to remove the ambiguity or change the variable name
  /Users/shinsukenishio/Projects/something/deps/ex_enum/mix.exs:12

warning: variable "description" does not exist and is being expanded to "description()", please use parentheses to remove the ambiguity or change the variable name
  /Users/shinsukenishio/Projects/something/deps/ex_enum/mix.exs:15

warning: variable "package" does not exist and is being expanded to "package()", please use parentheses to remove the ambiguity or change the variable name
  /Users/shinsukenishio/Projects/something/deps/ex_enum/mix.exs:16

Running dependency resolution...
All dependencies up to date


----
[nishio@nishio-local] $ iex -S mix phoenix.server

warning: variable "all" does not exist and is being expanded to "all()", please use parentheses to remove the ambiguity or change the variable name
  lib/ex_enum.ex:21

warning: variable "all" does not exist and is being expanded to "all()", please use parentheses to remove the ambiguity or change the variable name
  lib/ex_enum.ex:27

warning: variable "all" does not exist and is being expanded to "all()", please use parentheses to remove the ambiguity or change the variable name
  lib/ex_enum.ex:34

warning: variable "all" does not exist and is being expanded to "all()", please use parentheses to remove the ambiguity or change the variable name
  lib/ex_enum.ex:21

warning: variable "all" does not exist and is being expanded to "all()", please use parentheses to remove the ambiguity or change the variable name
  lib/ex_enum.ex:27

warning: variable "all" does not exist and is being expanded to "all()", please use parentheses to remove the ambiguity or change the variable name
  lib/ex_enum.ex:34
```

I'm using elixir 1.4.2.

```
[nishio@nishio-local] $ elixir -v
Erlang/OTP 19 [erts-8.3] [source] [64-bit] [smp:8:8] [async-threads:10] [hipe] [kernel-poll:false] [dtrace]

Elixir 1.4.2
```